### PR TITLE
Change SpinToColor to stop motor at end of command

### DIFF
--- a/src/main/java/frc/robot/commands/SpinToColor.java
+++ b/src/main/java/frc/robot/commands/SpinToColor.java
@@ -64,6 +64,7 @@ public class SpinToColor extends CommandBase {
     // Called once after isFinished returns true
     @Override
     public void end(boolean interrupted) {
+        colorSubsystem.stop();
     }
 
 }


### PR DESCRIPTION
Now the color wheel spinner will stop turning at the end of the command.